### PR TITLE
Clean up old releases (closes #3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,21 @@
 # static-site-deployer
 
-Scripts for managing deployment of snoonetIRC/static-web
+Scripts for managing deployment of snoonetIRC/static-web. No GitHub credentials
+are required as only the public API is used.
 
 ## Check release status
+
+Uses the public GitHub API to list available releases, and checks whether the
+latest release is installed in the provided directory.
 
 ```
 python3 updater.py check snoonetIRC/static-web path/to/website/dir
 ```
 
 ## Update release
+
+Attempts to download the most recent release into the provided directory. Also
+cleans up all but the five most recent releases from the directory.
 
 ```
 python3 updater.py update snoonetIRC/static-web path/to/website/dir

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ Scripts for managing deployment of snoonetIRC/static-web
 ## Check release status
 
 ```
-python3 updater.py check snoonetIRC/static-web
+python3 updater.py check snoonetIRC/static-web path/to/website/dir
 ```
 
 ## Update release
 
 ```
-python3 updater.py update snoonetIRC/static-web
+python3 updater.py update snoonetIRC/static-web path/to/website/dir
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # static-site-deployer
+
 Scripts for managing deployment of snoonetIRC/static-web
+
+## Check release status
+
+```
+python3 updater.py check snoonetIRC/static-web
+```
+
+## Update release
+
+```
+python3 updater.py update snoonetIRC/static-web
+```
+

--- a/updater.py
+++ b/updater.py
@@ -7,7 +7,6 @@ import os
 import sys
 import tarfile
 from pathlib import Path
-from pprint import pprint
 
 import requests
 from docopt import docopt
@@ -113,8 +112,6 @@ def do_cleanup(releases_dir, latest_release):
             removed += 1
         else:
             print('Cannot remove most recent release!')
-    else:
-        print('Did not run clean up (too few historic releases)')
 
     if removed > 0:
         print(f'Cleaned up {removed} historic releases')

--- a/updater.py
+++ b/updater.py
@@ -15,7 +15,7 @@ from shutil import rmtree
 
 ASSET_ID_FILE = '.asset_id'
 CURRENT_PATH = 'current'
-HISTORY_COUNT = 1
+HISTORY_COUNT = 5
 RELEASES_PATH = 'releases'
 
 RELEASE_URL = 'https://api.github.com/repos/{repo}/releases'

--- a/updater.py
+++ b/updater.py
@@ -9,6 +9,7 @@ import tarfile
 from pathlib import Path
 
 import requests
+from distutils.version import StrictVersion
 from docopt import docopt
 from shutil import rmtree
 
@@ -16,6 +17,7 @@ ASSET_ID_FILE = '.asset_id'
 CURRENT_PATH = 'current'
 HISTORY_COUNT = 5
 RELEASES_PATH = 'releases'
+RELEASE_PREFIX = 'website-v'
 
 RELEASE_URL = 'https://api.github.com/repos/{repo}/releases'
 
@@ -97,18 +99,20 @@ def do_update(args):
 
 
 def do_cleanup(releases_dir, latest_release):
-    files = os.listdir(releases_dir)
+    directories = os.listdir(releases_dir)
     removed = 0
 
-    if len(files) <= HISTORY_COUNT:
+    if len(directories) <= HISTORY_COUNT:
         print('Did not run clean-up (too few historic releases)')
         return
 
-    files.sort(reverse=True)
+    versions = [directory.replace(RELEASE_PREFIX, '') for directory in directories]
+    versions.sort(key=StrictVersion, reverse=True)
 
-    for f in files[HISTORY_COUNT:]:
-        if f != latest_release:
-            rmtree(releases_dir / f)
+    for version in versions[HISTORY_COUNT:]:
+        if version != latest_release:
+            release_name = RELEASE_PREFIX + version
+            rmtree(releases_dir / release_name)
             removed += 1
         else:
             print('Cannot remove most recent release!')

--- a/updater.py
+++ b/updater.py
@@ -103,14 +103,16 @@ def do_cleanup(releases_dir, latest_release):
     removed = 0
 
     if len(directories) <= HISTORY_COUNT:
-        print('Did not run clean-up (too few historic releases)')
+        print('Did not run clean up (too few historic releases)')
         return
 
+    # Trim "website-v" prefix for sorting with distutils.version
     versions = [directory.replace(RELEASE_PREFIX, '') for directory in directories]
     versions.sort(key=StrictVersion, reverse=True)
 
     for version in versions[HISTORY_COUNT:]:
-        if version != latest_release:
+        if RELEASE_PREFIX + version != latest_release:
+            # Replace the prefix for purging
             release_name = RELEASE_PREFIX + version
             rmtree(releases_dir / release_name)
             removed += 1
@@ -119,6 +121,8 @@ def do_cleanup(releases_dir, latest_release):
 
     if removed > 0:
         print(f'Cleaned up {removed} historic releases')
+    else:
+        print('No clean up required')
 
 
 def main():


### PR DESCRIPTION
Keeps the five most recent releases, `rmtree`s the rest. Should stop our web server filling up quite so quickly.